### PR TITLE
Adding tx_remaining method

### DIFF
--- a/libraries/DigisparkUSB/DigiUSB.cpp
+++ b/libraries/DigisparkUSB/DigiUSB.cpp
@@ -94,6 +94,10 @@ int DigiUSBDevice::available() {
    */
   return (RING_BUFFER_SIZE + _rx_buffer->head - _rx_buffer->tail) % RING_BUFFER_SIZE;
 }
+
+int DigiUSBDevice::tx_remaining() {
+  return RING_BUFFER_SIZE - (RING_BUFFER_SIZE + _tx_buffer->head - _tx_buffer->tail) % RING_BUFFER_SIZE;
+}
   
 int DigiUSBDevice::read() {
   /*

--- a/libraries/DigisparkUSB/DigiUSB.h
+++ b/libraries/DigisparkUSB/DigiUSB.h
@@ -46,6 +46,8 @@ class DigiUSBDevice : public Print {
   void refresh();
 
   int available();
+  int tx_remaining();
+  
   int read();
   virtual size_t write(byte c);
   using Print::write;


### PR DESCRIPTION
I found this code to be helpful, it's in response to Bluebie's post on the digistump discussion boards (http://digistump.com/board/index.php?p=/discussion/108/wish-digiusb-update-with-blocking-io-option-buffer-size-adjustment-tx-buffer-remaining-bytes).  

Used to avoid overloading the tx buffer, this will let you check ahead of time if there's enough room to do a DigiUSB.write().  For example:

``` C
if ( DigiUSB.tx_remaining() > sizeof("data I'm sending") ) {
      DigiUSB.write("data I'm sending");
}
```
