### PR TITLE
Separate the USB init process from the object initialization

### DIFF
--- a/libraries/DigisparkMouse/DigiMouse.h
+++ b/libraries/DigisparkMouse/DigiMouse.h
@@ -145,25 +145,18 @@ void clearMove() {
 class DigiMouseDevice {
  public:
 	DigiMouseDevice () {
-		// this timer stuff doesn't even make sense - it seems like someone got some code for Timer1
-		// and haphazardly changed the 1's in the register names to 0's, but the two timers don't work
-		// the same way, so this code doesn't do what it says at all. Is it even useful to have?
-		/* configure timer 0 for a rate of 16M5/(1024 * 256) = 62.94 Hz (~16ms) */
-		//TCCR0A = 5;			 /* timer 0 prescaler: 1024 */
-		
-		
-		
-		//TIMSK &= !(1<TOIE0);//interrupt off
-		cli();
-		usbDeviceDisconnect();
-		_delay_ms(250);
-		usbDeviceConnect();
-		
+
 		rt_usbHidReportDescriptor = mouse_usbHidReportDescriptor;
 		rt_usbHidReportDescriptorSize = sizeof(mouse_usbHidReportDescriptor);
 		rt_usbDeviceDescriptor = usbDescrDevice;
 		rt_usbDeviceDescriptorSize = sizeof(usbDescrDevice);
-		
+	}
+
+	void init() {
+		cli();
+		usbDeviceDisconnect();
+		_delay_ms(200);
+		usbDeviceConnect();	
 		
 		usbInit();
 		

--- a/libraries/DigisparkMouse/examples/Mouse/Mouse.ino
+++ b/libraries/DigisparkMouse/examples/Mouse/Mouse.ino
@@ -5,7 +5,7 @@
 #include "DigiMouse.h"
 
 void setup() {
-  // Do nothing? It seems as if the USB hardware is ready to go on reset
+  DigiMouse.init(); // call init to enumerate
 }
 
 void loop() {


### PR DESCRIPTION
The USB library triggers the enumeration using the commands usbDisconnect(), usbConnect().

If the USB library doesn't initialize correctly, it does not retry automatically, so if the USB host gives up in the enumeration (common in some embedded hosts) it will not be enumerated. 

With a separate init() one could test if the device fails to communicate via USB and re-trigger the enumeration by re-calling init().
